### PR TITLE
Pull actions with `package.dhall` straight from their repos

### DIFF
--- a/.github/.workflow_templates/ci.dhall
+++ b/.github/.workflow_templates/ci.dhall
@@ -6,8 +6,6 @@ let On = GHA.On
 
 let OS = GHA.OS.Type
 
-let actions-catalog = imports.actions-catalog
-
 let job-templates = imports.job-templates
 
 let Checkout = job-templates.actions/Checkout
@@ -29,7 +27,7 @@ in  GHA.Workflow::{
           , runs-on = [ OS.ubuntu-latest ]
           , steps =
               Checkout.plainDo
-                [ let action = actions-catalog.awseward/gh-actions-shell
+                [ let action = imports.gh-actions-shell
 
                   in  action.mkStep action.Common::{=} action.Inputs::{=}
                 ]
@@ -38,7 +36,7 @@ in  GHA.Workflow::{
           , runs-on = [ OS.ubuntu-latest ]
           , steps =
               Checkout.plainDo
-                [ let action = actions-catalog.awseward/gh-actions-dhall
+                [ let action = imports.gh-actions-dhall
 
                   in  action.mkStep action.Common::{=} action.Inputs::{=}
                 ]

--- a/.github/imports.dhall
+++ b/.github/imports.dhall
@@ -1,6 +1,12 @@
+let gh-actions-dhall =
+      https://raw.githubusercontent.com/awseward/gh-actions-dhall/0.4/package.dhall
+
+let gh-actions-shell =
+      https://raw.githubusercontent.com/awseward/gh-actions-shell/0.1/package.dhall
+
 let dhall-misc =
         env:DHALL_MISC
       ? https://raw.githubusercontent.com/awseward/dhall-misc/20210618093657/package.dhall
           sha256:401dd621799f1481244580856c2fd18f7c0ba9323c7b5b3a309b4e3017c9c57b
 
-in  dhall-misc.{ GHA, job-templates, actions-catalog }
+in  dhall-misc.{ GHA, job-templates } ⫽ { gh-actions-dhall, gh-actions-shell }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,10 @@ jobs:
       - ubuntu-latest
     steps:
       - uses: "actions/checkout@v2"
-      - uses: "awseward/gh-actions-dhall@0.3.2"
+      - uses: "awseward/gh-actions-dhall@0.4.0"
         with:
-          dhallVersion: '1.39.0'
+          dhallVersion: '1.40.2'
+          errorOnFreezeDiff: false
           typecheck_no_cache: false
           typecheck_package_files_only: false
   check-shell:
@@ -26,11 +27,7 @@ jobs:
       - ubuntu-latest
     steps:
       - uses: "actions/checkout@v2"
-      # Note: Running `_gen_actions` will likely undo the most recent change to
-      # this line… would like to try to think of some way to make routine
-      # changes like this less of a hassle; as it is I'm not sure anymore if
-      # it's worth it.
-      - uses: "awseward/gh-actions-shell@0.1"
+      - uses: "awseward/gh-actions-shell@0.1.7"
 
   # Note: Running `_gen_actions` will likely remove this whole block… I would
   # like to try to think of some way to make routine changes like this less of

--- a/package.dhall
+++ b/package.dhall
@@ -1,3 +1,5 @@
+let Inputs = ./inputs.dhall
+
 let imports =
       { GHA =
           https://raw.githubusercontent.com/awseward/dhall-misc/20210119042727/GHA/package.dhall
@@ -5,8 +7,6 @@ let imports =
       }
 
 let GHA = imports.GHA
-
-let Inputs = ./inputs.dhall
 
 let mkStep/next = GHA.actions.mkStep/next Inputs.Type Inputs.{ toJSON }
 


### PR DESCRIPTION
This cuts down on a step when upgrades need to happen.

Still some more issues to work through, but this is fine in the meantime… 🤷‍♂️